### PR TITLE
Fix arm32 build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,19 +28,6 @@ fn build_syscall(rustc_toolchain: &str, target_arch: &str) {
     //println!("cargo::rustc-check-cfg=cfg(nc_has_asm)");
     println!("cargo:rustc-check-cfg=cfg(nc_has_asm)");
 
-    // Automatically detect if thumb-mode is an available feature by looking at
-    // the prefix of the target. Currently, the thumb-mode target feature is
-    // only set automatically in nightly builds, so we must do the manual
-    // feature detect here.
-    //
-    // "armv7-linux-androideabi" is a special case that has thumb-mode enabled,
-    // but does not start with the "thumb" prefix.
-    if env::var("TARGET").map_or(false, |t| {
-        t.starts_with("thumb") || t == "armv7-linux-androideabi" 
-    }) {
-        println!("cargo:rustc-cfg=target_feature=\"thumb-mode\"");
-    }
-
     // - aarch64/arm/riscv64/x86/x86_64: support inline assembly in stable version
     // - others: enable inline assembly in nightly version.
     //

--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,19 @@ fn build_syscall(rustc_toolchain: &str, target_arch: &str) {
     //println!("cargo::rustc-check-cfg=cfg(nc_has_asm)");
     println!("cargo:rustc-check-cfg=cfg(nc_has_asm)");
 
+    // Automatically detect if thumb-mode is an available feature by looking at
+    // the prefix of the target. Currently, the thumb-mode target feature is
+    // only set automatically in nightly builds, so we must do the manual
+    // feature detect here.
+    //
+    // "armv7-linux-androideabi" is a special case that has thumb-mode enabled,
+    // but does not start with the "thumb" prefix.
+    if env::var("TARGET").map_or(false, |t| {
+        t.starts_with("thumb") || t == "armv7-linux-androideabi" 
+    }) {
+        println!("cargo:rustc-cfg=target_feature=\"thumb-mode\"");
+    }
+
     // - aarch64/arm/riscv64/x86/x86_64: support inline assembly in stable version
     // - others: enable inline assembly in nightly version.
     //

--- a/src/syscalls/syscall_arm.rs
+++ b/src/syscalls/syscall_arm.rs
@@ -13,8 +13,10 @@ use super::types::{check_errno, Errno, Sysno};
 #[inline]
 pub unsafe fn syscall0(n: Sysno) -> Result<usize, Errno> {
     let ret: usize;
-    asm!("swi 0",
-         in("r7") n,
+    asm!(
+        "mov r7, {n}",
+        "swi 0",
+         n = in(reg) n,
          lateout("r0") ret,
     );
     check_errno(ret)
@@ -23,8 +25,10 @@ pub unsafe fn syscall0(n: Sysno) -> Result<usize, Errno> {
 #[inline]
 pub unsafe fn syscall1(n: Sysno, a1: usize) -> Result<usize, Errno> {
     let ret: usize;
-    asm!("swi 0",
-         in("r7") n,
+    asm!(
+        "mov r7, {n}",
+        "swi 0",
+         n = in(reg) n,
          in("r0") a1,
          lateout("r0") ret,
     );
@@ -34,8 +38,10 @@ pub unsafe fn syscall1(n: Sysno, a1: usize) -> Result<usize, Errno> {
 #[inline]
 pub unsafe fn syscall2(n: Sysno, a1: usize, a2: usize) -> Result<usize, Errno> {
     let ret: usize;
-    asm!("swi 0",
-         in("r7") n,
+    asm!(
+        "mov r7, {n}",
+        "swi 0",
+         n = in(reg) n,
          in("r0") a1,
          in("r1") a2,
          lateout("r0") ret,
@@ -46,8 +52,10 @@ pub unsafe fn syscall2(n: Sysno, a1: usize, a2: usize) -> Result<usize, Errno> {
 #[inline]
 pub unsafe fn syscall3(n: Sysno, a1: usize, a2: usize, a3: usize) -> Result<usize, Errno> {
     let ret: usize;
-    asm!("swi 0",
-         in("r7") n,
+    asm!(
+        "mov r7, {n}",
+        "swi 0",
+         n = in(reg) n,
          in("r0") a1,
          in("r1") a2,
          in("r2") a3,
@@ -65,8 +73,10 @@ pub unsafe fn syscall4(
     a4: usize,
 ) -> Result<usize, Errno> {
     let ret: usize;
-    asm!("swi 0",
-         in("r7") n,
+    asm!(
+        "mov r7, {n}",
+        "swi 0",
+         n = in(reg) n,
          in("r0") a1,
          in("r1") a2,
          in("r2") a3,
@@ -86,8 +96,10 @@ pub unsafe fn syscall5(
     a5: usize,
 ) -> Result<usize, Errno> {
     let ret: usize;
-    asm!("swi 0",
-         in("r7") n,
+    asm!(
+        "mov r7, {n}",
+        "swi 0",
+         n = in(reg) n,
          in("r0") a1,
          in("r1") a2,
          in("r2") a3,
@@ -109,8 +121,10 @@ pub unsafe fn syscall6(
     a6: usize,
 ) -> Result<usize, Errno> {
     let ret: usize;
-    asm!("swi 0",
-         in("r7") n,
+    asm!(
+        "mov r7, {n}",
+        "swi 0",
+         n = in(reg) n,
          in("r0") a1,
          in("r1") a2,
          in("r2") a3,


### PR DESCRIPTION
arm32 builds were complaining about `r7` usage on syscalls
```
error: cannot use register r7: the frame pointer (r7) cannot be used as an operand for inline asm
```
This PR fixes it by explicitly moving the syscall number to `r7` from another register